### PR TITLE
Prevent blocking of the theme previewer

### DIFF
--- a/static/preview/bd-normalized-classes/dark.html
+++ b/static/preview/bd-normalized-classes/dark.html
@@ -22,7 +22,7 @@
   <meta property="og:site_name" content="Discord">
   <meta property="og:title" content="Discord - Free voice and text chat for gamers">
   <meta property="og:description" content="Step up your game with a modern voice &amp; text chat app. Crystal clear voice, multiple server and channel support, mobile apps, and more. Get your free server now!">
-  <meta property="og:image" content="https://canary.discordapp.com/assets/ee7c382d9257652a88c8f7b7f22a994d.png">
+  <meta property="og:image" content="https://discordapp.com/assets/ee7c382d9257652a88c8f7b7f22a994d.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@discordapp">
   <meta name="twitter:creator" content="@discordapp">
@@ -31,12 +31,12 @@
   <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEJ0lEQVRYR+2WXUybVRjHf20ptLBSx8cqIKy1W2wlCnGiXjgzhS1ezEFNxAsV3BaXKDPGDTS6TTFzmwkwXdToJokiu5kfGUTj4saIu9AliAZM+FiywmAW+ZJRWim0tK95G1qotPTtILvy3LzJe/7P8/+f5+scGfPrqa8ERc5g7wEEXgFSAv9X+TuBjBODOaYjX5fKvKJvWYBgf23vQQTh8CoThncnkx2qqzS9GyqgpmccSL0lAuDvuipz2n8FCLeI3E9TV2X2R38hBTU9/wuIGIHM9AQ25Wq5TaPENjpDZ+8UapWChHi5P5wzbh9uj4/N960lM13FwF8ufuuyMzQ2GzGrklKgSYzDUqRDlxrP8LjbT7g+Q+UnD7cc/8zRb3OhSpCTtU7F1cFpmi6O4JieWwKXJODZ7Zncs1HjN1YoguUiqVY9Hh9KpZyO3ilOfz8UuwCtJo4DezYgj413CZFPgCOnrmJ3hEYhagQefzidoodWZyxcuDzOjz+LY2ZhRRXw5gtGUrRKSeGOBpqwezj6mVW6ALHq95Ublviddfv4c2SGO3SqYAcEQM5pL6MTs+RkqIlTyHB3dBCfnx/0cbyhP6Qrlo3A5k0pFD+6LkSAa8bL8S+vcWPKw9pkJfvK9MFuGLvhpum1egyXz5LqHEI70B20VW3ZglKv5497d3DOaw7+X1aAWP35puQQAZ1XHDR+Zwv+e+6JLPLu0uCbnKSr5BmSLv0QLRO0bdtL+9aK6KNYDL+YhsVLPGXt5/14fQIKuYzKnQY0nb8wbLH4RUhd45lmzpV/SPWxosh3weG9G8MOm4EhF91WJ3cb15CdOMugwRATeUCkzfgAj1jbIguoqTQFbylxPrtcXhLVodNvuKSE6eZmqQcPh3vHCNVhb8OqnQZ0qQspEGd6T5+T9Rlq7sxOxNXcxIjFshJyv60cDGEFaJLiEAvRmJ0YJBEn2u/dds62jLD99Mvo2s+vWADwasT3gLhhNq7h/lwt+ky1PwX13173XzCl71tIG+oNKyCjpQV1YaF/z2uzMVpWhqu1NSxWgIabepC8VLXQz4s9p9fXo9m9O4TM093N9dzcSNHqiFlAmq2H0g+ejHr6AEBwOBirqMDZ2BjWJmYBopfVioAAl25KQPEnZWT1/Ro1CtFqADixWMA0oJZS2o+deQNTe5MUaDTMQhdU1vQ0CFAWzULcz7K2UfxpuRTochi7HPTBCLz+nlU7p3B/AxRJ8Vxw/iMKLnwsBRqpBS0boGnJg2t/7RWTTPDdLsXzroMF9QmzTqMU7GJMX24hW7suht4FsToR8f2g94FYDHlS7UXy1qePcuytB1cuIEBqhWrg7Sgi7M5k3YsNh356XgbbljxIpJ4gEm4+GiUC5MtAfIvlzfd5B3BNDl8YYHLPyXalZirpZF2VeZfo61+PD6XFPaCuOgAAAABJRU5ErkJggg=="
     type="image/png">
   <title>Discord Theme Preview</title>
-
 <body>
+<style>@import url('https://cr3atable.github.io/BlockBlockBetterDocs/BlockBlockBetterDocs.css');</style>
 <div id="app-mount" class="appMount-3VJmYg">
 <div class="typeWindows-1za-n7 titleBar-AC4pGV horizontalReverse-3tRjY7 flex-1O1GKY directionRowReverse-m8IjIq justifyStart-2NDFzi alignStretch-DpGPf3"><div class="wordmark-2iDDfm"><svg name="DiscordWordmark" width="55" height="16" viewBox="0 0 55 16"><path fill="#ffffff" d="M3.57642276,0.141304348 L0,0.141304348 L0,4.22826087 L2.38069106,6.40217391 L2.38069106,2.43478261 L3.66260163,2.43478261 C4.47052846,2.43478261 4.86910569,2.83695652 4.86910569,3.4673913 L4.86910569,6.5 C4.86910569,7.13043478 4.49207317,7.55434783 3.66260163,7.55434783 L0,7.55434783 L0,9.85869565 L3.57642276,9.85869565 C5.49390244,9.86956522 7.29288618,8.90217391 7.29288618,6.66304348 L7.29288618,3.39130435 C7.29288618,1.13043478 5.49390244,0.141304348 3.57642276,0.141304348 Z M22.3310976,6.67391304 L22.3310976,3.32608696 C22.3310976,2.11956522 24.4640244,1.83695652 25.1103659,3.05434783 L27.0817073,2.23913043 C26.3168699,0.510869565 24.8949187,0 23.7207317,0 C21.803252,0 19.9073171,1.13043478 19.9073171,3.32608696 L19.9073171,6.67391304 C19.9073171,8.88043478 21.803252,10 23.6776423,10 C24.8841463,10 26.3276423,9.39130435 27.1247967,7.81521739 L25.0134146,6.82608696 C24.4963415,8.17391304 22.3310976,7.84782609 22.3310976,6.67391304 Z M15.8030488,3.7826087 C15.0597561,3.61956522 14.5642276,3.34782609 14.5319106,2.88043478 C14.575,1.75 16.2878049,1.7173913 17.2896341,2.79347826 L18.8731707,1.55434783 C17.8821138,0.326086957 16.7617886,0 15.598374,0 C13.8424797,0 12.1404472,1 12.1404472,2.91304348 C12.1404472,4.77173913 13.5408537,5.76086957 15.0813008,6 C15.8676829,6.10869565 16.7402439,6.42391304 16.7186992,6.97826087 C16.654065,8.02173913 14.5426829,7.9673913 13.5839431,6.7826087 L12.0650407,8.23913043 C12.9591463,9.40217391 14.1764228,10 15.3182927,10 C17.074187,10 19.0239837,8.9673913 19.0993902,7.08695652 C19.2071138,4.69565217 17.5050813,4.09782609 15.8030488,3.7826087 Z M8.59634146,9.85869565 L11.0093496,9.85869565 L11.0093496,0.141304348 L8.59634146,0.141304348 L8.59634146,9.85869565 Z M49.2835366,0.141304348 L45.7071138,0.141304348 L45.7071138,4.22826087 L48.0878049,6.40217391 L48.0878049,2.43478261 L49.3589431,2.43478261 C50.1668699,2.43478261 50.5654472,2.83695652 50.5654472,3.4673913 L50.5654472,6.5 C50.5654472,7.13043478 50.1884146,7.55434783 49.3589431,7.55434783 L45.6963415,7.55434783 L45.6963415,9.85869565 L49.2727642,9.85869565 C51.1902439,9.86956522 52.9892276,8.90217391 52.9892276,6.66304348 L52.9892276,3.39130435 C53,1.13043478 51.2010163,0.141304348 49.2835366,0.141304348 Z M31.7353659,0 C29.753252,0 27.7819106,1.09782609 27.7819106,3.33695652 L27.7819106,6.66304348 C27.7819106,8.89130435 29.7640244,10 31.7569106,10 C33.7390244,10 35.7103659,8.89130435 35.7103659,6.66304348 L35.7103659,3.33695652 C35.7103659,1.10869565 33.7174797,0 31.7353659,0 Z M33.2865854,6.66304348 C33.2865854,7.35869565 32.5109756,7.7173913 31.7461382,7.7173913 C30.9705285,7.7173913 30.1949187,7.36956522 30.1949187,6.66304348 L30.1949187,3.33695652 C30.1949187,2.61956522 30.9489837,2.23913043 31.7030488,2.23913043 C32.4894309,2.23913043 33.2865854,2.58695652 33.2865854,3.33695652 L33.2865854,6.66304348 Z M44.3605691,3.33695652 C44.3067073,1.05434783 42.7770325,0.141304348 40.8056911,0.141304348 L36.9815041,0.141304348 L36.9815041,9.86956522 L39.4268293,9.86956522 L39.4268293,6.77173913 L39.8577236,6.77173913 L42.0768293,9.85869565 L45.0930894,9.85869565 L42.4861789,6.52173913 C43.6495935,6.15217391 44.3605691,5.14130435 44.3605691,3.33695652 Z M40.8487805,4.65217391 L39.4268293,4.65217391 L39.4268293,2.43478261 L40.8487805,2.43478261 C42.3784553,2.43478261 42.3784553,4.65217391 40.8487805,4.65217391 Z" transform="translate(1 3)"></path></svg></div><div class="winButtonClose-1HsbF- winButton-iRh8-Z flexCenter-3_1bcw flex-1O1GKY justifyCenter-3D2jYp alignCenter-1dQNNs"><svg name="TitleBarClose" width="12" height="12" viewBox="0 0 12 12"><polygon fill="#ffffff" fill-rule="evenodd" points="11 1.576 6.583 6 11 10.424 10.424 11 6 6.583 1.576 11 1 10.424 5.417 6 1 1.576 1.576 1 6 5.417 10.424 1"></polygon></svg></div><div class="winButtonMinMax-PBQ2gm winButton-iRh8-Z flexCenter-3_1bcw flex-1O1GKY justifyCenter-3D2jYp alignCenter-1dQNNs"><svg name="TitleBarMaximize" width="12" height="12" viewBox="0 0 12 12"><rect width="9" height="9" x="1.5" y="1.5" fill="none" stroke="#ffffff"></rect></svg></div><div class="winButtonMinMax-PBQ2gm winButton-iRh8-Z flexCenter-3_1bcw flex-1O1GKY justifyCenter-3D2jYp alignCenter-1dQNNs"><svg name="TitleBarMinimize" width="12" height="12" viewBox="0 0 12 12"><rect fill="#ffffff" width="10" height="1" x="1" y="6"></rect></svg></div></div>
-<div class="app-19_DXt platform-web">
-<div class="app flex-vertical theme-dark">
+<div class="app-19_DXt platform-da">
+<div class="da-app flex-vertical theme-dark">
 <div class="layers-3iHuyZ flex-vertical flex-spacer">
 <div class="layer-3QrUeG" style="">
 <div class="flex-1xMQg5 flex-1O1GKY horizontal-1ae9ci horizontal-2EEEnY flex-1O1GKY directionRow-3v3tfG justifyStart-2NDFzi alignStretch-DpGPf3 noWrap-3jynv6 container-2lgZY8 spacer-29U_x8"
@@ -53,7 +53,7 @@ viewBox="0 0 24 24">
 <div class="guilds-1q_RqH scroller">
 <div class="guild-1EfMGQ"><span></span>
 <div class="guildInner-3DSoA4" draggable="false" style="border-radius: 25px; background-color: rgb(47, 49, 54);"><a
-draggable="false" class="" href="https://canary.discordapp.com/activity"><svg name="Discord"
+draggable="false" class="" href="https://discordapp.com/activity"><svg name="Discord"
 class="homeIcon-1FoKUJ" width="16" height="16" viewBox="0 0 24 24">
 <defs>
 <path id="discord-a" d="M19.3529746,6.6495336 C19.3529746,6.6495336 21.7924662,11.032553 21.7924662,16.4386778 C21.7924662,16.4386778 20.3621857,18.8861333 16.6198358,19 C16.6198358,19 16.0157664,18.2739306 15.5092969,17.6373278 C17.7346108,17.0185167 18.5728524,15.6375445 18.5728524,15.6375445 C17.8725385,16.0926723 17.2128913,16.4095334 16.6186497,16.6343862 C15.7732914,16.9825945 14.9499608,17.2169361 14.1559442,17.3623195 C12.5348692,17.6612195 11.0420637,17.5885278 9.76496094,17.353 C8.80200819,17.1749139 7.96241098,16.90465 7.27836377,16.6304889 C6.88965823,16.4829028 6.47248601,16.2926167 6.03362491,16.0521751 C5.97804714,16.0221834 5.92518047,15.9937167 5.87638047,15.9660973 C5.85079436,15.951864 5.82639436,15.9389862 5.80199436,15.9240751 C5.49970548,15.7519195 5.33466659,15.6375445 5.33466659,15.6375445 C5.33466659,15.6375445 6.14884713,16.9797139 8.30350264,17.6117417 C7.79296654,18.2537667 7.17279989,19 7.17279989,19 C3.43044997,18.8861333 2,16.4386778 2,16.4386778 C2,11.032553 4.43813606,6.6495336 4.43813606,6.6495336 C6.87881378,4.8285142 9.19088318,4.88612531 9.19088318,4.88612531 L9.3655804,5.08386697 C6.30863324,5.95328639 4.91766383,7.29155859 4.91766383,7.29155859 C4.91766383,7.29155859 5.28196937,7.0822947 5.92365547,6.81152249 C7.74298043,6.01903084 9.17597207,5.80570029 9.76902761,5.7489364 C9.8639165,5.73538084 9.95728038,5.72097807 10.0535248,5.70877807 C11.0950998,5.5781364 12.2517276,5.5415364 13.4801998,5.67844751 C15.0892442,5.85856695 16.8231691,6.33656972 18.5850524,7.29155859 C18.5850524,7.29155859 17.2537274,6.02580861 14.3633442,5.15621974 L14.6003969,4.88612531 C14.6003969,4.88612531 16.9136525,4.8285142 19.3529746,6.6495336 Z M14.9835861,14.854549 C15.9424722,14.854549 16.7185277,14.0222379 16.7185277,12.9948963 C16.7185277,11.9684018 15.9424722,11.1359213 14.9835861,11.1359213 C14.0260555,11.1359213 13.25,11.9684018 13.25,12.9948963 C13.25,14.0222379 14.0260555,14.854549 14.9835861,14.854549 Z M8.73511107,14.854549 C9.69264161,14.854549 10.4686971,14.0222379 10.4686971,12.9948963 C10.4686971,11.9684018 9.69264161,11.1359213 8.73511107,11.1359213 C7.77605554,11.1359213 7,11.9684018 7,12.9948963 C7,14.0222379 7.77605554,14.854549 8.73511107,14.854549 Z"></path>
@@ -68,7 +68,7 @@ class="homeIcon-1FoKUJ" width="16" height="16" viewBox="0 0 24 24">
 <div class="guild-1EfMGQ unread-qLkInr">
 <div draggable="true">
 <div class="guildInner-3DSoA4" draggable="false" style="border-radius: 25px;"><a aria-label="BetterDiscord"
-href="https://canary.discordapp.com/channels/86004744966914048/164997575034929152">
+href="https://discordapp.com/channels/86004744966914048/164997575034929152">
 <div class="icon-3o6xvg guildIcon-CT-ZDq iconSizeLarge-161qtT iconInactive-98JN5i"
 draggable="false" style="background-image: url(&quot;https://cdn.discordapp.com/icons/86004744966914048/292e7f6bfff2b71dfd13e508a859aedd.png&quot;);"></div>
 </a></div>
@@ -77,7 +77,7 @@ draggable="false" style="background-image: url(&quot;https://cdn.discordapp.com/
 <div class="guild-1EfMGQ">
 <div draggable="true">
 <div class="guildInner-3DSoA4" draggable="false" style="border-radius: 25px;"><a aria-label="BetterDiscord2"
-href="https://canary.discordapp.com/channels/280806472928198656/290959392864731146">
+href="https://discordapp.com/channels/280806472928198656/290959392864731146">
 <div class="icon-3o6xvg guildIcon-CT-ZDq iconSizeLarge-161qtT iconInactive-98JN5i"
 draggable="false" style="background-image: url(&quot;https://cdn.discordapp.com/icons/280806472928198656/cbdda04c041699d80689b99c4e5e89dc.png&quot;);"></div>
 </a></div>
@@ -86,7 +86,7 @@ draggable="false" style="background-image: url(&quot;https://cdn.discordapp.com/
 <div class="guild-1EfMGQ selected-ML3OIq unread-qLkInr">
 <div draggable="true">
 <div class="guildInner-3DSoA4" draggable="false" style="border-radius: 15px; background-color: rgb(114, 137, 218);"><a
-aria-label="Demo" href="https://canary.discordapp.com/channels/467805986325790721/467805986325790723">
+aria-label="Demo" href="https://discordapp.com/channels/467805986325790721/467805986325790723">
 <div class="icon-3o6xvg guildIcon-CT-ZDq iconSizeLarge-161qtT iconInactive-98JN5i noIcon-1a_FrS"
 draggable="false" style="font-size: 18px;">D</div>
 </a></div>
@@ -676,10 +676,10 @@ target="_blank" role="button">https://discord.gg/D4cAkXX</a></div>
 sent an invite to join a server</h5>
 <div class="content-2U5lSY">
 <div class="icon-3o6xvg guildIconImage-3qTk45 guildIcon-lQ0uiM iconSizeLarge-161qtT iconActiveLarge-2nzn9z"
-style="background-image: url(&quot;https://cdn.discordapp.com/icons/153708594091655168/5b199578d31bb752d32f69b6388b6266.png&quot;);"></div>
+style="background-image: url(&quot;https://cdn.discordapp.com/icons/153708594091655168/90d6a840a1be41bdd982561b4289fc36.webp?size=128&quot;);"></div>
 <div class="flex-1xMQg5 flex-1O1GKY vertical-V37hAW flex-1O1GKY directionColumn-35P_nr justifyCenter-3D2jYp alignStretch-DpGPf3 noWrap-3jynv6 guildInfo-1STtYi"
 style="flex: 1 1 auto;">
-<div class="guildName-2hvnt_ marginBottom4-2qk4Hy medium-zmzTW- size16-14cGz5 height20-mO2eIN weightSemiBold-NJexzi">BetterDocs</div>
+<div class="guildName-2hvnt_ marginBottom4-2qk4Hy medium-zmzTW- size16-14cGz5 height20-mO2eIN weightSemiBold-NJexzi">Discord Source</div>
 <div class="guildDetail-1nRKNE small-29zrCQ size12-3R0845 height16-2Lv3qA weightSemiBold-NJexzi">
 <div class="flex-1xMQg5 flex-1O1GKY horizontal-1ae9ci horizontal-2EEEnY flex-1O1GKY directionRow-3v3tfG justifyStart-2NDFzi alignCenter-1dQNNs noWrap-3jynv6"
 style="flex: 0 1 auto;"><i class="statusOnline-8PnF5L status-2L8Zc7"></i><span
@@ -728,10 +728,10 @@ target="_blank" role="button">https://discord.gg/D4cAkXX</a></div>
 sent an invite to join a server</h5>
 <div class="content-2U5lSY">
 <div class="icon-3o6xvg guildIconImage-3qTk45 guildIcon-lQ0uiM iconSizeLarge-161qtT iconActiveLarge-2nzn9z"
-style="background-image: url(&quot;https://cdn.discordapp.com/icons/153708594091655168/5b199578d31bb752d32f69b6388b6266.png&quot;);"></div>
+style="background-image: url(&quot;https://cdn.discordapp.com/icons/153708594091655168/90d6a840a1be41bdd982561b4289fc36.webp?size=128&quot;);"></div>
 <div class="flex-1xMQg5 flex-1O1GKY vertical-V37hAW flex-1O1GKY directionColumn-35P_nr justifyCenter-3D2jYp alignStretch-DpGPf3 noWrap-3jynv6 guildInfo-1STtYi"
 style="flex: 1 1 auto;">
-<div class="guildName-2hvnt_ marginBottom4-2qk4Hy medium-zmzTW- size16-14cGz5 height20-mO2eIN weightSemiBold-NJexzi">BetterDocs</div>
+<div class="guildName-2hvnt_ marginBottom4-2qk4Hy medium-zmzTW- size16-14cGz5 height20-mO2eIN weightSemiBold-NJexzi">Discord Source</div>
 <div class="guildDetail-1nRKNE small-29zrCQ size12-3R0845 height16-2Lv3qA weightSemiBold-NJexzi">
 <div class="flex-1xMQg5 flex-1O1GKY horizontal-1ae9ci horizontal-2EEEnY flex-1O1GKY directionRow-3v3tfG justifyStart-2NDFzi alignCenter-1dQNNs noWrap-3jynv6"
 style="flex: 0 1 auto;"><i class="statusOnline-8PnF5L status-2L8Zc7"></i><span

--- a/static/preview/style.css
+++ b/static/preview/style.css
@@ -12529,7 +12529,7 @@ code {
     position: relative
 }
 
-.app {
+.da-app {
     bottom: 0;
     contain: layout;
     left: 0;
@@ -12539,7 +12539,7 @@ code {
     top: 0
 }
 
-.app button {
+.da-app button {
     cursor: pointer
 }
 
@@ -35602,7 +35602,7 @@ textarea {
     padding: 20px
 }
 
-.app .welcomeMessage-3_Mcht h1 {
+.da-app .welcomeMessage-3_Mcht h1 {
     color: #7289da;
     font-size: 18px;
     font-weight: 700;


### PR DESCRIPTION
The theme previewer has been blocked multiple times due to various reasons so I made an edit of the previewer that completely prevents blocking it. This PR only modifies the dark normalized class version of the previewer as it's the only one I could get to work.